### PR TITLE
Fix NPE when a poison sequence resets mid-sequence

### DIFF
--- a/src/main/java/com/poisonednpcs/combat/PoisonTracker.java
+++ b/src/main/java/com/poisonednpcs/combat/PoisonTracker.java
@@ -46,9 +46,6 @@ public class PoisonTracker {
             current = Optional.of(newPoisonSequence(hit));
         }
 
-        // register that the poison splat happened -- this is intentional even though it returns no value
-        current.get().splat();
-
         int amount = hit.getHitsplat().getAmount();
         int expectedNextDamage = current.get().nextExpectedDamage();
         // TODO: any way to do this sequence without if statements?
@@ -68,6 +65,10 @@ public class PoisonTracker {
             current.get().nextStep();
             current.get().markAmbiguous();
         }
+
+        // Register that the poison splat happened. We do this AFTER the above sequence checks to make sure that
+        // any reset sequence is properly splatted as well.
+        current.get().splat();
 
         // if we just applied our last piece of poison damage, kill the sequence altogether
         if (current.get().isFinished()) {

--- a/src/test/java/com/poisonednpcs/combat/PoisonTrackerTest.java
+++ b/src/test/java/com/poisonednpcs/combat/PoisonTrackerTest.java
@@ -37,6 +37,7 @@ public class PoisonTrackerTest extends TestCase {
         assertTrue(tracker.getPoisonStatus().isPresent());
         assertFalse(tracker.getPoisonStatus().get().isAmbiguous());
         assertTrue(tracker.isPoisoned());
+        assertNotNull(tracker.getPoisonStatus().get().getLastSplat());
     }
 
     public void testRegisterRestartSplat() {
@@ -59,6 +60,11 @@ public class PoisonTrackerTest extends TestCase {
         assertTrue(tracker.getPoisonStatus().isPresent());
         assertFalse(tracker.getPoisonStatus().get().isAmbiguous());
         assertTrue(tracker.isPoisoned());
+
+        // Ensure that a sequence which is reset is properly configured to handle the next splat. This just means that
+        // once a sequence is reset, the next splat should function properly. A previous bug resulted in the timestamp
+        // of the resetting splat not being marked in the new sequence, which threw NPEs.
+        assertNotNull(tracker.getPoisonStatus().get().getLastSplat());
     }
 
     public void testRegisterAmbiguousSplat() {
@@ -81,6 +87,7 @@ public class PoisonTrackerTest extends TestCase {
         assertTrue(tracker.getPoisonStatus().isPresent());
         assertTrue(tracker.getPoisonStatus().get().isAmbiguous());
         assertTrue(tracker.isPoisoned());
+        assertNotNull(tracker.getPoisonStatus().get().getLastSplat());
     }
 
     public void testRegisterFullSequence() {


### PR DESCRIPTION
The pre-existing implementation had a bug whereby poison resetting from more than one damage greater than expectation (i.e., poison sequence started at 5, has ticked down to 3, then poison resets from additional hits and a 5 hitsplat is receive) would wipe the record of the current sequence in favor of a fresh sequence but the hitsplat which restarted the sequence would not have its timestamp recorded.

This resulted in a NPE when the timer calculating the next estimated hit was called, as the `Instant` against which the calculation would take place was null and unchecked. That NPE would crash the plugin for all in-combat opponents until each poison splat had completed a full cycle.

The fix is to move the last splat timestamp recording until after sequence handling has taken place.

For posterity, an example of the NPE stack trace:
```java.lang.NullPointerException: Cannot invoke "java.time.Instant.plus(java.time.temporal.TemporalAmount)" because the return value of "com.poisonednpcs.combat.PoisonState.getLastSplat()" is null
	at com.poisonednpcs.combat.PoisonTracker.getNextExpectedSplat(PoisonTracker.java:87)
	at com.poisonednpcs.health.Tracking.timeUntilPoisonSplat(Tracking.java:34)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.poisonednpcs.health.PoisonWatchTimer.getText(PoisonWatchTimer.java:39)
	at net.runelite.client.ui.overlay.infobox.InfoBoxOverlay.render(InfoBoxOverlay.java:137)
	at net.runelite.client.ui.overlay.OverlayRenderer.safeRender(OverlayRenderer.java:734)
	at net.runelite.client.ui.overlay.OverlayRenderer.renderOverlays(OverlayRenderer.java:328)
	at net.runelite.client.ui.overlay.OverlayRenderer.renderOverlayLayer(OverlayRenderer.java:235)
	at net.runelite.client.callback.Hooks.drawAboveOverheads(Hooks.java:509)
	at li.ep(li.java:46921)
	at li.av(li.java:122)
	at gm.jo(gm.java:5268)
	at jy.mn(jy.java:11355)
	at jy.mn(jy.java:11386)
	at dy.ma(dy.java:11250)
	at client.zn(client.java:4940)
	at client.bl(client.java:1250)
	at bs.bj(bs.java:418)
	at bs.gh(bs.java)
	at bs.run(bs.java:9050)
	at java.base/java.lang.Thread.run(Thread.java:840)
```